### PR TITLE
add analogWriteResolution in begin to fix pwm output

### DIFF
--- a/src/pwm.h
+++ b/src/pwm.h
@@ -59,6 +59,7 @@ class PwmTx {
   explicit PwmTx(const std::array<int8_t, N> &pins) : pins_(pins) {}
   void Begin() {
     Begin(pwm_freq_hz_);
+    analogWriteResolution(RES_);
   }
   void Begin(const float freq) {
     pwm_period_us_ = 1.0f / freq * 1000000.0f;


### PR DESCRIPTION
PWM output does not work without setting analogWriteResolution in begin function 